### PR TITLE
azure: RHEL-10 specific customization

### DIFF
--- a/Containerfile.el10-azure
+++ b/Containerfile.el10-azure
@@ -4,62 +4,105 @@ ARG CONTAINERFILE=Containerfile
 COPY $CONTAINERFILE /root/Containerfile
 COPY azure /root
 
-RUN dnf install -y \
-	"@Server" \
-	"NetworkManager" \
-	"NetworkManager-cloud-setup" \
-	"WALinuxAgent" \
-	"azure-vm-utils" \
-	"bzip2" \
-	"cloud-init" \
-	"cloud-utils-growpart" \
-	"efibootmgr" \
-	"hyperv-daemons" \
-	"langpacks-en" \
-	"lvm2" \
-	"nvme-cli" \
-	"patch" \
-	"rng-tools" \
-	"rsync" \
-	"selinux-policy-targeted" \
-	"system-reinstall-bootc" \
-	"uuid" \
-	"yum-utils" \
-	--exclude="NetworkManager-config-server" \
-	--exclude="alsa-lib" \
-	--exclude="biosdevname" \
-	--exclude="bolt" \
-	--exclude="buildah" \
-	--exclude="cockpit-podman" \
-	--exclude="containernetworking-plugins" \
-	--exclude="dnf-plugin-spacewalk" \
-	--exclude="dracut-config-rescue" \
-	--exclude="glibc-all-langpacks" \
-	--exclude="initscripts-rename-device" \
-	--exclude="iprutils" \
-	--exclude="microcode_ctl" \
-	--exclude="plymouth" \
-	--exclude="podman" \
-	--exclude="python3-dnf-plugin-spacewalk" \
-	--exclude="python3-hwdata" \
-	--exclude="python3-rhnlib" \
-	--exclude="rhn-check" \
-	--exclude="rhn-client-tools" \
-	--exclude="rhn-setup" \
-	--exclude="rhnlib" \
-	--exclude="rhnsd" \
-	--exclude="usb_modeswitch" \
-	--exclude="*-firmware"
+# WALinuxAgent, NetworkManager, and cloud-init are integrated.
+RUN dnf -y install \
+	WALinuxAgent \
+	NetworkManager \
+	cloud-init \
+	cloud-utils-growpart \
+	firewalld \
+	hyperv-daemons && \
+	dnf clean all
 
-RUN echo 'kargs = ["ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
+RUN <<EORUN
+# common kernel arguments
+mkdir -p /usr/lib/bootc/kargs.d
+echo 'kargs = ["ro"]' > /usr/lib/bootc/kargs.d/50-azure-common.toml
 
-COPY --chown=root:root --chmod=0755 azure/usr/local/sbin/temp-disk-dataloss-warning /usr/local/sbin/temp-disk-dataloss-warning
-COPY --chown=root:root --chmod=0644 azure/etc/systemd/system/temp-disk-dataloss-warning.service /etc/systemd/system/temp-disk-dataloss-warning.service
+# x86_64 kernel arguments
+cat <<'EOF' > /usr/lib/bootc/kargs.d/50-azure-x86_64.toml
+match-architectures = ["x86_64"]
+kargs = [
+    "console=tty1",
+    "console=ttyS0",
+    "earlyprintk=ttyS0",
+    "rootdelay=300"
+]
+EOF
+
+# aarch64 kernel arguments
+cat <<'EOF' > /usr/lib/bootc/kargs.d/50-azure-aarch64.toml
+match-architectures = ["aarch64"]
+kargs = [
+    "console=ttyAMA0"
+]
+EOF
+
+# grub configuration
+cat <<'EOF' > /etc/default/grub
+GRUB_TIMEOUT=10
+GRUB_TIMEOUT_STYLE=countdown
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=y
+GRUB_TERMINAL="serial console"
+GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+GRUB_DISABLE_RECOVERY="true"
+EOF
+
+# nm-cloud-setup configuration
+mkdir -p /etc/systemd/system/nm-cloud-setup.service.d/
+cat <<'EOF' > /etc/systemd/system/nm-cloud-setup.service.d/10-rh-enable-for-azure.conf
+[Service]
+Environment="NM_CLOUD_SETUP_AZURE=yes"
+EOF
+
+# ensure global networking is enabled and ZeroConf is disabled
+cat <<'EOF' >> /etc/sysconfig/network
+NETWORKING=yes
+NOZEROCONF=yes
+EOF
+
+# mellanox is managed by Azure
+mkdir -p /etc/NetworkManager/conf.d
+cat <<'EOT' > /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+[keyfile]
+unmanaged-devices=driver:mlx4_core;driver:mlx5_core;
+EOT
+
+# waagent configuration
+sed -i 's/Provisioning.Agent=auto/Provisioning.Agent=cloud-init/g' /etc/waagent.conf
+sed -i 's/ResourceDisk.Format=y/ResourceDisk.Format=n/g' /etc/waagent.conf
+sed -i 's/ResourceDisk.EnableSwap=y/ResourceDisk.EnableSwap=n/g' /etc/waagent.conf
+
+# fix for Azure Load Balancer
+echo 'ClientAliveInterval 180' >> /etc/ssh/sshd_config
+
+# acpi_cpufreq, intel_cstate: prevent guest OS from interfering with hypervisor-level power management.
+# amdgpu, nouveau, lbm-nouveau: disable physical GPU drivers to reduce boot time and attack surface.
+# floppy: disable legacy hardware support not present in Azure.
+# skx_edac, intel_uncore: disable hardware-specific monitoring/error correction that is redundant or inaccessible in a VM.
+echo 'blacklist acpi_cpufreq amdgpu intel_cstate floppy nouveau lbm-nouveau skx_edac intel_uncore' >> /etc/modprobe.d/blacklist.conf
+
+# pwquality configuration
+echo 'minlen = 6' >> /etc/security/pwquality.conf
+echo 'minclass = 3' >> /etc/security/pwquality.conf
+EORUN
+
+# copy and update permissions for other files
+COPY azure/etc /etc
+COPY azure/usr /usr
+RUN <<EORUN
+chmod 0755 /usr/local/sbin/temp-disk-dataloss-warning
+EORUN
 
 RUN systemctl enable \
-	"firewalld" \
-	"nm-cloud-setup.service" \
-	"nm-cloud-setup.timer" \
-	"sshd" \
-	"temp-disk-dataloss-warning.service" \
-	"waagent"
+	waagent \
+	cloud-init \
+	NetworkManager.service \
+	nm-cloud-setup.service \
+	nm-cloud-setup.timer \
+	firewalld \
+	hypervkvpd \
+	hypervvssd \
+	temp-disk-dataloss-warning.service

--- a/Containerfile.el10-ec2
+++ b/Containerfile.el10-ec2
@@ -19,14 +19,8 @@ RUN dnf install -y \
 	"system-reinstall-bootc" \
 	"tar" \
 	"tuned" \
-	"yum-utils" \
-	--exclude="biosdevname" \
-	--exclude="dracut-config-rescue" \
-	--exclude="firewalld" \
-	--exclude="iprutils" \
-	--exclude="plymouth" \
-	--exclude="qemu-guest-agent" \
-	--exclude="*-firmware"
+	"yum-utils" && \
+	dnf clean all
 
 RUN echo 'kargs = ["console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
 

--- a/Containerfile.el10-gce
+++ b/Containerfile.el10-gce
@@ -23,19 +23,8 @@ RUN dnf install -y \
 	"tar" \
 	"timedatex" \
 	"tuned" \
-	"vim" \
-	--exclude="alsa-utils" \
-	--exclude="b43-fwcutter" \
-	--exclude="b43-openfwwf" \
-	--exclude="dmraid" \
-	--exclude="dracut-config-rescue" \
-	--exclude="eject" \
-	--exclude="gpm" \
-	--exclude="irqbalance" \
-	--exclude="microcode_ctl" \
-	--exclude="qemu-guest-agent" \
-	--exclude="smartmontools" \
-	--exclude="*-firmware"
+	"vim" && \
+	dnf clean all
 
 RUN echo 'kargs = ["biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
 

--- a/Containerfile.el10-qcow2
+++ b/Containerfile.el10-qcow2
@@ -24,19 +24,7 @@ RUN dnf install -y \
 	"system-reinstall-bootc" \
 	"tar" \
 	"tcpdump" \
-	"tuned" \
-	--exclude="alsa-lib" \
-	--exclude="biosdevname" \
-	--exclude="dnf-plugin-spacewalk" \
-	--exclude="dracut-config-rescue" \
-	--exclude="fedora-release" \
-	--exclude="fedora-repos" \
-	--exclude="firewalld" \
-	--exclude="iprutils" \
-	--exclude="langpacks-*" \
-	--exclude="plymouth" \
-	--exclude="rng-tools" \
-	--exclude="udisks2" \
-	--exclude="*-firmware"
+	"tuned" && \
+	dnf clean all
 
 RUN echo 'kargs = ["console=tty0 console=ttyS0,115200n8"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml

--- a/Containerfile.el9-azure
+++ b/Containerfile.el9-azure
@@ -25,34 +25,8 @@ RUN dnf install -y \
 	"selinux-policy-targeted" \
 	"system-reinstall-bootc" \
 	"uuid" \
-	"yum-utils" \
-	--exclude="NetworkManager-config-server" \
-	--exclude="bolt" \
-	--exclude="buildah" \
-	--exclude="cockpit-podman" \
-	--exclude="containernetworking-plugins" \
-	--exclude="dnf-plugin-spacewalk" \
-	--exclude="glibc-all-langpacks" \
-	--exclude="initscripts-rename-device" \
-	--exclude="microcode_ctl" \
-	--exclude="podman" \
-	--exclude="python3-dnf-plugin-spacewalk" \
-	--exclude="python3-hwdata" \
-	--exclude="python3-rhnlib" \
-	--exclude="rhn-check" \
-	--exclude="rhn-client-tools" \
-	--exclude="rhn-setup" \
-	--exclude="rhnlib" \
-	--exclude="rhnsd" \
-	--exclude="usb_modeswitch" \
-	--exclude="dracut-config-rescue" \
-	--exclude="alsa-lib" \
-	--exclude="biosdevname" \
-	--exclude="iprutils" \
-	--exclude="plymouth" \
-	--exclude="*-firmware" && \
-	dnf clean all && \
-	rm -rf /var/cache/dnf
+	"yum-utils" && \
+	dnf clean all
 
 RUN echo 'kargs = ["ro console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"]' > /usr/lib/bootc/kargs.d/50-azure.toml
 

--- a/Containerfile.el9-ec2
+++ b/Containerfile.el9-ec2
@@ -20,17 +20,8 @@ RUN dnf install -y \
 	"redhat-release" \
 	"redhat-release-eula" \
 	"system-reinstall-bootc" \
-	"yum-utils" \
-	--exclude="firewalld" \
-	--exclude="qemu-guest-agent" \
-	--exclude="dracut-config-rescue" \
-	--exclude="alsa-lib" \
-	--exclude="biosdevname" \
-	--exclude="iprutils" \
-	--exclude="plymouth" \
-	--exclude="*-firmware" && \
-	dnf clean all && \
-	rm -rf /var/cache/dnf
+	"yum-utils" && \
+	dnf clean all
 
 RUN echo 'kargs = ["console=tty0 console=ttyS0,115200n8 net.ifnames=0 nvme_core.io_timeout=4294967295"]' > /usr/lib/bootc/kargs.d/50-ec2.toml
 

--- a/Containerfile.el9-gce
+++ b/Containerfile.el9-gce
@@ -24,21 +24,8 @@ RUN dnf install -y \
 	"python3" \
 	"rng-tools" \
 	"timedatex" \
-	"vim" \
-	--exclude="alsa-utils" \
-	--exclude="b43-fwcutter" \
-	--exclude="b43-openfwwf" \
-	--exclude="dmraid" \
-	--exclude="eject" \
-	--exclude="gpm" \
-	--exclude="irqbalance" \
-	--exclude="microcode_ctl" \
-	--exclude="qemu-guest-agent" \
-	--exclude="smartmontools" \
-	--exclude="dracut-config-rescue" \
-	--exclude="*-firmware" && \
-	dnf clean all && \
-	rm -rf /var/cache/dnf
+	"vim" && \
+	dnf clean all
 
 RUN echo 'kargs = ["net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y console=ttyS0,38400n8d"]' > /usr/lib/bootc/kargs.d/50-gce.toml
 

--- a/Containerfile.el9-qcow2
+++ b/Containerfile.el9-qcow2
@@ -24,23 +24,7 @@ RUN dnf install -y \
 	"qemu-guest-agent" \
 	"redhat-release" \
 	"redhat-release-eula" \
-	"tcpdump" \
-	--exclude="dnf-plugin-spacewalk" \
-	--exclude="fedora-release" \
-	--exclude="fedora-repos" \
-	--exclude="firewalld" \
-	--exclude="langpacks-*" \
-	--exclude="langpacks-en" \
-	--exclude="nss" \
-	--exclude="rng-tools" \
-	--exclude="udisks2" \
-	--exclude="dracut-config-rescue" \
-	--exclude="alsa-lib" \
-	--exclude="biosdevname" \
-	--exclude="iprutils" \
-	--exclude="plymouth" \
-	--exclude="*-firmware" && \
-	dnf clean all && \
-	rm -rf /var/cache/dnf
+	"tcpdump" && \
+	dnf clean all
 
 RUN echo 'kargs = ["console=tty0 console=ttyS0,115200n8 net.ifnames=0"]' > /usr/lib/bootc/kargs.d/50-qcow2.toml

--- a/Containerfile.fedora-azure
+++ b/Containerfile.fedora-azure
@@ -11,16 +11,8 @@ RUN dnf install -y --skip-unavailable \
     "WALinuxAgent" \
     "azure-vm-utils" \
     "hyperv-daemons" \
-    "kernel-modules" \
-    --exclude="dracut-config-rescue" \
-    --exclude="firewalld" \
-    --exclude="fwupd" \
-    --exclude="geolite2-city" \
-    --exclude="geolite2-country" \
-    --exclude="plymouth" \
-    --exclude="*-firmware" && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    "kernel-modules" && \
+    dnf clean all
 
 RUN echo 'kargs = ["console=tty1 console=ttyS0,115200n8 systemd.firstboot=off no_timer-check"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
 

--- a/Containerfile.fedora-ec2
+++ b/Containerfile.fedora-ec2
@@ -10,16 +10,8 @@ RUN dnf install -y --skip-unavailable \
     "python3-dnf-plugin-tracer" \
     "amazon-ec2-utils" \
     "awscli2" \
-    "ec2-instance-connect" \
-    --exclude="dracut-config-rescue" \
-    --exclude="firewalld" \
-    --exclude="fwupd" \
-    --exclude="geolite2-city" \
-    --exclude="geolite2-country" \
-    --exclude="plymouth" \
-    --exclude="*-firmware" && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    "ec2-instance-connect" && \
+    dnf clean all
 
 RUN echo 'kargs = ["console=tty1 console=ttyS0,115200n8 systemd.firstboot=off no_timer-check"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
 

--- a/Containerfile.fedora-gce
+++ b/Containerfile.fedora-gce
@@ -10,16 +10,7 @@ RUN dnf install -y --skip-unavailable \
     "python3-dnf-plugin-tracer" \
     "google-compute-engine-guest-configs" \
     "google-compute-engine-oslogin" \
-    "google-guest-agent" \
-    --exclude="cloud-init" \
-    --exclude="dracut-config-rescue" \
-    --exclude="firewalld" \
-    --exclude="fwupd" \
-    --exclude="geolite2-city" \
-    --exclude="geolite2-country" \
-    --exclude="plymouth" \
-    --exclude="*-firmware" && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    "google-guest-agent" && \
+    dnf clean all
 
 RUN echo 'kargs = ["console=tty1 console=ttyS0,115200n8 systemd.firstboot=off no_timer-check"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml

--- a/Containerfile.fedora-qcow2
+++ b/Containerfile.fedora-qcow2
@@ -8,16 +8,8 @@ RUN dnf install -y --skip-unavailable \
     "btrfs-progs" \
     "glibc-langpack-en" \
     "python3-dnf-plugin-tracer" \
-    "qemu-guest-agent" \
-    --exclude="dracut-config-rescue" \
-    --exclude="firewalld" \
-    --exclude="fwupd" \
-    --exclude="geolite2-city" \
-    --exclude="geolite2-country" \
-    --exclude="plymouth" \
-    --exclude="*-firmware" && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+    "qemu-guest-agent" && \
+    dnf clean all
 
 RUN echo 'kargs = ["console=tty1 console=ttyS0,115200n8 systemd.firstboot=off no_timer-check"]' > /usr/lib/bootc/kargs.d/50-image-builder.toml
 

--- a/Containerfile.foundry
+++ b/Containerfile.foundry
@@ -10,11 +10,10 @@ RUN dnf install -y \
     skopeo \
     subscription-manager \
     git \
-    && dnf clean all \
-    && rm -rf /var/cache/dnf
+    && dnf clean all
 
 # AppStream is only available when building this on a registered system (e.g. RHOS)
-RUN if [ -z "${UPSTREAM:-}" ]; then dnf install -y awscli2; fi
+RUN if [ -z "${UPSTREAM:-}" ]; then dnf install -y awscli2 && dnf clean all; fi
 
 WORKDIR /workspace
 COPY . /workspace

--- a/azure/etc/cloud/cloud.cfg.d/05_logging.cfg
+++ b/azure/etc/cloud/cloud.cfg.d/05_logging.cfg
@@ -1,0 +1,4 @@
+# This tells cloud-init to redirect its stdout and stderr to
+# 'tee -a /var/log/cloud-init-output.log' so the user can see output
+# there without needing to look on the console.
+output: {all: '| tee -a /var/log/cloud-init-output.log'}

--- a/azure/etc/cloud/cloud.cfg.d/91-azure_datasource.cfg
+++ b/azure/etc/cloud/cloud.cfg.d/91-azure_datasource.cfg
@@ -1,0 +1,4 @@
+datasource_list: [ Azure ]
+datasource:
+    Azure:
+        apply_network_config: False

--- a/azure/usr/lib/bootc/install/05-cloud-kargs.toml
+++ b/azure/usr/lib/bootc/install/05-cloud-kargs.toml
@@ -1,0 +1,6 @@
+[install]
+# See also:
+# - https://github.com/coreos/fedora-coreos-config/blob/testing-devel/platforms.yaml
+# - https://github.com/osbuild/images/blob/63a1eead26a7c802dbcebe863439f591be6dc6e5/pkg/distro/rhel9/qcow2.go#L159
+# - https://learn.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic?source=recommendations#general-linux-system-requirements
+kargs = ["rootdelay=300", "console=tty0", "console=ttyS0,115200n8", "earlyprintk=ttyS0", "net.iframes=0"]


### PR DESCRIPTION
The Containerfiles were generated from our distrodefs and this commit fine-tunes them for the initial version we want to start with.

---

All `Containerfile` files in this repo were created using one-time script from our distrodef YAML definitions (package includes/excludes, services, files, directories and kernel arguments). Since these are definitions for package-based images and because we are building something different here and we do not necessary need parity, I am opening this PR so we can discuss what to remove, what to keep. This first PR is only for Azure, I will do follow-ups for other image types.

I am assuming this repo is new for all of you, I suggest you read the main README first. But in short, these Containerfiles start with an incorrect `FROM` verb which is missing tag, this is because they are always built with the correct `--from` argument. Each distribution (Fedora, CentOS Stream 9/10) has a set of 4 files per each image type. Depending on the outcome of these PR discussions, we might end up with less files but this is currently how the CICD pipeline expects everything to be set. For each PR, all combinations of OSes, versions, arches and image types are built and for merged commits these are also pushed to `quay.io` (RHEL is only built we will do this downstream only).

Now, each Containerfile start with this:

```
ARG CONTAINERFILE=Containerfile
COPY $CONTAINERFILE /root/Containerfile
COPY azure /root
```

The idea is to ship the `Containerfile` itself and everything it needs in the bootc image itself in `/root` so users can rebuild their instances easily. Then all necessary packages for the particular image type are installed. Only then, resource files are copied over (to ensure directories are already created by the package management tool). Then various customizations are done and finally, services are enabled.

In the initial commit of this PR, we are starting with **an extreme change** - I am changing from our distrodefs which include and exclude a ton of packages and services to the opposite extreme: minimum possible Containerfile as shown in the [bootc-examples repo](https://github.com/redhat-cop/rhel-bootc-examples). With one actual change - data loss service is kept which I already find useful to have. Or not? Let's find out!

@achilleas-k @croissanne @supakeen @thozza @ondrejbudai @lucasgarfield @ochosi 

Edit: Tests are red, well, will fix later :-)