### PR TITLE
cicd: schutzbot build pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,43 +1,113 @@
 stages:
   - init
-  - test
+  - run
   - finish
 
+.base:
+  variables:
+    ARCHES: "x86_64"
+    TYPES: "qcow2"
+    FEDORA_VERSION: "43"
+    EL9_VERSION: "9.7"
+    EL10_VERSION: "10.1"
+    FROM_REFS: |-
+      quay.io/fedora/fedora-bootc:${FEDORA_VERSION}
+      quay.io/centos-bootc/centos-bootc:stream10
+      quay.io/centos-bootc/centos-bootc:stream9
+      registry.redhat.io/rhel9/rhel-bootc:${EL9_VERSION}
+      registry.redhat.io/rhel10/rhel-bootc:${EL10_VERSION}
+
+.terraform:
+  extends: .base
+  tags:
+    - terraform
+
 init:
+  extends: .base
   stage: init
   interruptible: true
   tags:
     - shell
   script:
-    - schutzbot/update_github_status.sh start
+    - |
+      for FROM_REF in $FROM_REFS; do
+        schutzbot/update_github_status.sh start "$FROM_REF"
+      done
 
-test:
-  before_script:
-    - mkdir -p /tmp/artifacts
-    - schutzbot/ci_details.sh > /tmp/artifacts/ci-details-before-run.txt
-    - cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
-  script:
-    - schutzbot/noop.sh
-  after_script:
-    - schutzbot/ci_details.sh > /tmp/artifacts/ci-details-after-run.txt || true
-    - schutzbot/unregister.sh || true
-    - schutzbot/update_github_status.sh update || true
-    - schutzbot/save_journal.sh || true
-    - schutzbot/upload_artifacts.sh
-  tags:
-    - terraform/openstack
+run:
+  extends: .terraform
+  stage: run
   parallel:
     matrix:
-      # available runners: https://github.com/osbuild/gitlab-ci-terraform
-      - RUNNER:
-          - aws/centos-stream-10-x86_64
-          - aws/rhel-10.1-ga-x86_64
-        INTERNAL_NETWORK: ["true"]
+      - FROM_REF: "quay.io/fedora/fedora-bootc:${FEDORA_VERSION}"
+        CONTAINERFILE: "fedora"
+        RUNNER: "aws/centos-stream-10-x86_64"
+        FROM_CREDS: ""
+        DST_REF: "quay.io/osbuild/fedora-bootc:${FEDORA_VERSION}"
+        DST_CREDS: "$QUAY_CREDS"
+
+      - FROM_REF: "registry.redhat.io/rhel9/rhel-bootc:${EL9_VERSION}"
+        CONTAINERFILE: "el9"
+        RUNNER: "aws/rhel-10.1-ga-x86_64"
+        FROM_CREDS: "$RH_CREDS"
+        DST_REF: ""
+        DST_CREDS: ""
+
+      - FROM_REF: "quay.io/centos-bootc/centos-bootc:stream10"
+        CONTAINERFILE: "el10"
+        RUNNER: "aws/centos-stream-10-x86_64"
+        FROM_CREDS: ""
+        DST_REF: "quay.io/osbuild/centos-bootc:stream10"
+        DST_CREDS: "$QUAY_CREDS"
+
+      - FROM_REF: "quay.io/centos-bootc/centos-bootc:stream9"
+        CONTAINERFILE: "el9"
+        RUNNER: "aws/centos-stream-10-x86_64"
+        FROM_CREDS: ""
+        DST_REF: "quay.io/osbuild/centos-bootc:stream9"
+        DST_CREDS: "$QUAY_CREDS"
+
+      - FROM_REF: "registry.redhat.io/rhel10/rhel-bootc:${EL10_VERSION}"
+        CONTAINERFILE: "el10"
+        RUNNER: "aws/rhel-10.1-ga-x86_64"
+        FROM_CREDS: "$RH_CREDS"
+        DST_REF: ""
+        DST_CREDS: ""
+
+  before_script:
+    - . schutzbot/gitlab-utils.sh
+    - section_start before_script "Run before script section"
+    - schutzbot/ec2-spot-check.sh &
+    - mkdir -p /tmp/artifacts && schutzbot/ci_details.sh > /tmp/artifacts/ci-details-before-run.txt
+    - cat schutzbot/team_ssh_keys.txt | tee -a ~/.ssh/authorized_keys > /dev/null
+    - sudo dnf -y install buildah
+    - |
+      # Push only on main branch
+      if [ "$CI_COMMIT_BRANCH" != "main" ]; then
+        unset DST_CREDS
+      fi
+    - section_end before_script
+  script:
+    - schutzbot/build.sh
+  after_script:
+    - . schutzbot/gitlab-utils.sh
+    - section_start after_script "Run after script section"
+    - schutzbot/ci_details.sh > /tmp/artifacts/ci-details-after-run.txt || true
+    - schutzbot/unregister.sh || true
+    - schutzbot/update_github_status.sh update "$FROM_REF" || true
+    - schutzbot/save_journal.sh || true
+    - schutzbot/upload_artifacts.sh
+    - if [ "$CI_JOB_STATUS" = "success" ]; then schutzbot/update_github_status.sh finish "$FROM_REF"; fi
+    - section_end after_script
 
 finish:
+  extends: .base
   stage: finish
   dependencies: []
   tags:
     - shell
   script:
-    - schutzbot/update_github_status.sh finish
+    - |
+      for FROM_REF in $FROM_REFS; do
+        schutzbot/update_github_status.sh finish "$FROM_REF"
+      done

--- a/Containerfile.comment
+++ b/Containerfile.comment
@@ -1,0 +1,6 @@
+#
+# TODO: This comment will be replaced with explanation on how to use the Containerfile
+# to rebuild a bootable container deployment once we get to testing those images.
+#
+# https://github.com/osbuild/bootc-foundry/issues/9
+#

--- a/Containerfile.el10-qcow2
+++ b/Containerfile.el10-qcow2
@@ -1,0 +1,3 @@
+FROM quay.io/centos-bootc/centos-bootc
+
+RUN echo TODO

--- a/Containerfile.el9-qcow2
+++ b/Containerfile.el9-qcow2
@@ -1,0 +1,3 @@
+FROM quay.io/centos-bootc/centos-bootc
+
+RUN echo TODO

--- a/Containerfile.fedora-qcow2
+++ b/Containerfile.fedora-qcow2
@@ -1,0 +1,3 @@
+FROM quay.io/fedora/fedora-bootc
+
+RUN echo TODO

--- a/schutzbot/README.md
+++ b/schutzbot/README.md
@@ -1,0 +1,33 @@
+# Schutzbot
+
+This directory contains GitHub -> GitLab CI/CD pipeline.
+
+## The workflow:
+
+* GitHub Action `.github/workflows/trigger-gitlab.yml` checkouts the branch and pushes it into GitLab.
+* GitLab starts CI/CD pipeline based on `.gitlab-ci.yml`.
+* Terraform is checked out (`schutzbot/terraform`) and deploys runner instances.
+* Terraform Executor prepares the runners.
+* Script `schutzbot/update_github_status.sh` sets GitHub state to pending.
+* Runners execute scripts from `schutzbot/`
+* Script `schutzbot/update_github_status.sh` updates GitHub to final state.
+
+## GitLab Repo
+
+https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-foundry
+
+## Creating a new setup
+
+* Create GitHub/GitLab repositories.
+* Make sure GitLab project that is *public*.
+* Create `.github/workflows/trigger-gitlab.yml`.
+* Set required GitHub Action variables.
+* Create `.gitlab-ci.yml`.
+* Set required GitLab CICD variables.
+
+## Other links
+
+* https://github.com/osbuild/image-builder-terraform
+* https://github.com/osbuild/gitlab-ci-config
+* https://github.com/osbuild/gitlab-ci-terraform
+* https://github.com/osbuild/gitlab-ci-terraform-executor

--- a/schutzbot/build.sh
+++ b/schutzbot/build.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# Builds and creates multi-arch manifest; optionally pushes. Required variables:
+#
+# FROM_REF - base ref (e.g. quay.io/fedora/fedora-bootc:43)
+# DST_REF - destination ref image without image type suffix (e.g. quay.io/osbuild/fedora-bootc:43)
+# CONTAINERFILE - containerfile suffix without type (e.g. fedora → Containerfile.fedora-xxx)
+#
+# Optional variables:
+#
+# ARCHES - space-separated list of architectures to cross-build
+# TYPES - space-separated list of image types to build
+# FROM_CREDS - colon-separated username:password for source registry (empty for public registries)
+# DST_CREDS - colon-separated username:password for destination registry (empty for no push)
+# CACHE_REF - sidecar cache registry
+# CACHE_CREDS - colon-separated username:password for cache registry (required if CACHE_REF is set)
+
+. "$(dirname "$0")/gitlab-utils.sh"
+
+if [ -n "${FROM_CREDS:-}" ] && [[ "${FROM_CREDS}" == *:* ]]; then
+  FROM_USER="${FROM_CREDS%%:*}"
+  FROM_PASS="${FROM_CREDS#*:}"
+  section_start login_from_registry "Logging in to $FROM_REF"
+  TO_REGISTRY=$(echo "$FROM_REF" | cut -d/ -f1)
+  echo "$FROM_PASS" | buildah login -u "$FROM_USER" --password-stdin "$TO_REGISTRY"
+  section_end login_from_registry
+fi
+
+if [ -n "${DST_CREDS:-}" ] && [[ "${DST_CREDS}" == *:* ]]; then
+  DST_USER="${DST_CREDS%%:*}"
+  DST_PASS="${DST_CREDS#*:}"
+  section_start login_dst_registry "Logging in to $DST_REF"
+  TO_REGISTRY=$(echo "$DST_REF" | cut -d/ -f1)
+  echo "$DST_PASS" | buildah login -u "$DST_USER" --password-stdin "$TO_REGISTRY"
+  section_end login_dst_registry
+fi
+
+if [ -n "${CACHE_REF:-}" ] && [ -n "${CACHE_CREDS:-}" ] && [[ "${CACHE_CREDS}" == *:* ]]; then
+  CACHE_USER="${CACHE_CREDS%%:*}"
+  CACHE_PASS="${CACHE_CREDS#*:}"
+  section_start login_cache_ref "Logging in to $CACHE_REF (cache will be used)"
+  CACHE_REGISTRY=$(echo "$CACHE_REF" | cut -d/ -f1)
+  echo "$CACHE_PASS" | buildah login -u "$CACHE_USER" --password-stdin "$CACHE_REGISTRY"
+  section_end login_cache_ref
+
+  section_start pull_cache "Pulling from cache ref ${CACHE_REF}"
+  echo "Using cache $CACHE_REF"
+  buildah pull "$CACHE_REF" || true
+  buildah pull "$FROM_REF"
+  section_end pull_cache
+
+  section_start push_to_cache "Pushing to cache ref ${CACHE_REF}"
+  buildah push "$FROM_REF" "$CACHE_REF" || true
+  section_end push_to_cache
+fi
+
+NOPUSH=
+if [ -z "${DST_REF:-}" ]; then
+  DST_REF="local"
+  NOPUSH=1
+fi
+
+ARCHES=${ARCHES:-x86_64}
+TYPES=${TYPES:-qcow2}
+DST_REF=${DST_REF:-local}
+
+for ARCH in $ARCHES; do
+  for TYPE in $TYPES; do
+    section_start prepare_containerfile "Preparing Containerfile with FROM ${FROM_REF}"
+    cp "Containerfile.comment" "Containerfile"
+    {
+      echo "FROM ${FROM_REF}"
+      echo "ARG BUILD_DATE=$(date +%Y-%m-%d)"
+      tail -n +2 "Containerfile.${CONTAINERFILE}-${TYPE}"
+    } >> "Containerfile"
+    cat "Containerfile"
+    section_end prepare_containerfile
+
+    section_start "build_${ARCH}_${TYPE}" "Building $FROM_REF arch $ARCH type $TYPE"
+    buildah build --layers --arch="$ARCH" \
+      --build-arg CONTAINERFILE="Containerfile" \
+      --from "${FROM_REF}" \
+      -f "Containerfile" \
+      -t "$DST_REF-$ARCH-$TYPE" .
+    section_end "build_${ARCH}_${TYPE}"
+  done
+done
+
+for TYPE in $TYPES; do
+  for ARCH in $ARCHES; do
+    section_start "push_${ARCH}_${TYPE}" "Pushing $DST_REF-$ARCH-$TYPE to registry"
+    if [ -n "${DST_CREDS:-}" ] && [ -z "${NOPUSH:-}" ]; then
+      echo "Pushing $DST_REF-$ARCH-$TYPE to registry"
+      buildah push "$DST_REF-$ARCH-$TYPE"
+    else
+      echo "Push skipped: DST_CREDS missing or NOPUSH set"
+    fi
+    section_end "push_${ARCH}_${TYPE}"
+  done
+done
+
+section_start create_manifest "Creating manifest for $DST_REF"
+buildah manifest create "$DST_REF"
+section_end create_manifest
+
+for TYPE in $TYPES; do
+  section_start "add_to_manifest_${TYPE}" "Adding $TYPE to $DST_REF manifest"
+  for ARCH in $ARCHES; do
+    buildah manifest add "$DST_REF" "$DST_REF-$ARCH-$TYPE"
+  done
+  section_end "add_to_manifest_${TYPE}"
+
+  if [ -n "${DST_CREDS:-}" ] && [ -z "${NOPUSH:-}" ]; then
+    section_start "push_manifest_${TYPE}" "Pushing manifest $DST_REF to registry"
+    buildah manifest push --all "$DST_REF" "docker://$DST_REF"
+    section_end "push_manifest_${TYPE}"
+  else
+    echo "Push skipped: DST_CREDS missing or NOPUSH set"
+  fi
+done

--- a/schutzbot/ec2-spot-check.sh
+++ b/schutzbot/ec2-spot-check.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Run this script in the background to shut down the GitLab runner gracefully on
+# AWS EC2 spot termination. Does nothing for non-EC2 environments.
+
+if [ -f /sys/class/dmi/id/product_uuid ]; then
+	UUID=$(tr '[:upper:]' '[:lower:]' < /sys/class/dmi/id/product_uuid)
+	if [[ "$UUID" != ec2* ]]; then
+		exit 0
+	fi
+else
+	exit 0
+fi
+
+while true; do
+	TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+	HTTP_CODE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s -w "%{http_code}" -o /dev/null http://169.254.169.254/latest/meta-data/spot/instance-action)
+
+	if [ "$HTTP_CODE" -eq 200 ]; then
+		MSG="EC2 Spot Interruption detected! Shutting down GitLab Runner gracefully."
+		echo "$MSG"
+		logger -t spot-monitor "$MSG"
+		BODY=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/spot/instance-action)
+		echo "$BODY"
+		logger -t spot-monitor "$BODY"
+
+		schutzbot/update_github_status.sh spot "$FROM_REF" || true
+		gitlab-runner stop
+		break
+	fi
+
+	sleep 30
+done

--- a/schutzbot/gitlab-utils.sh
+++ b/schutzbot/gitlab-utils.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hide "set +x"/"set -x" from trace when possible (BASH_XTRACEFD).
+_trace_quiet() {
+  exec 3>/dev/null 2>/dev/null || true
+  BASH_XTRACEFD=3 set +x 2>/dev/null || set +x
+}
+
+_trace_restore() {
+  BASH_XTRACEFD=3 set -x 2>/dev/null || set -x
+}
+
+# Prints a section start message to the console.
+#
+# Arguments:
+#   $1 - section id
+#   $2 - section title
+#   $3 - collapsed (optional)
+#
+# Example:
+#   section_start build_image "Building image"
+function section_start() {
+  _trace_quiet
+  local section_id="${1}_$$"
+  local section_title=$2
+  local collapsed=${3:-true}
+  local params=""
+  [ "$collapsed" == "true" ] && params="[collapsed=true]"
+
+  printf "\e[0Ksection_start:%s:%s%s\r\e[0K\e[1;36m%s\e[0m\n" "$(date +%s)" "$section_id" "$params" "$section_title"
+  _trace_restore
+}
+
+# Prints a section end message to the console.
+#
+# Arguments:
+#   $1 - section id
+#
+# Example:
+#   section_end build_image
+function section_end() {
+  _trace_quiet
+  local section_id="${1}_$$"
+  printf "\e[0Ksection_end:%s:%s\r\e[0K\n" "$(date +%s)" "$section_id"
+  _trace_restore
+}

--- a/schutzbot/noop.sh
+++ b/schutzbot/noop.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-exit 0

--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -17,6 +17,9 @@ if [[ $1 == "start" ]]; then
 elif [[ $1 == "finish" ]]; then
   GITHUB_NEW_STATE="success"
   GITHUB_NEW_DESC="I like this commit!"
+elif [[ $1 == "spot" ]]; then
+  GITHUB_NEW_STATE="failure"
+  GITHUB_NEW_DESC="Bad luck, AWS EC2 spot instance was terminated."
 elif [[ $1 == "update" ]]; then
   if [[ $CI_JOB_STATUS == "canceled" ]]; then
     GITHUB_NEW_STATE="failure"
@@ -28,13 +31,13 @@ elif [[ $1 == "update" ]]; then
     exit 0
   fi
 else
-  echo "unknown command"
+  echo "Unknown command: $1"
   exit 1
 fi
 
 CONTEXT="Schutzbot on GitLab"
-if [[ "$CI_PIPELINE_SOURCE" == "schedule" ]]; then
-    CONTEXT="$CONTEXT, RHEL-${RHEL_MAJOR:-}-nightly"
+if [[ -n "$2" ]]; then
+    CONTEXT="$CONTEXT: $2"
 fi
 
 curl \


### PR DESCRIPTION
This PR implements a new GitLab-based build pipeline. Added qcow2 containerfiles for el9, el10, fedora which have one dummy `RUN` command that does nothing. I do want us to discuss the pipeline first, once this is merged we can focus on qcow2 Containerfiles.

The pipeline is based on what we have in `image-builder-frontend` which was the latest Schutzbot deployment as I was told. I had to modify it and improve it a little bit:

* Added `schutzbot/gitlab-utils.sh` which allows for the GitLab log folding for more readability
* Added `schutzbot/ec2-spot-check.sh` which tracks spot instance termination on AWS and sets status accordingly
* Modified `schutzbot/update_github_status.sh` to take context as a second argument and took advantage of that
* Added `schutzbot/README.md` which is an attempt to document the process

For the pipeline itself, it is pretty straightforward. I wanted the GitHub status to be per-runner so that is why I pass the context and init/finish separately, I could not figure better solution. We want the status to be reported ASAP so people do not accidentally merge "green" GH PRs (while GL is still pending).

The build itself is just one shell script called `build.sh` that takes bunch of variables and then does the build. It has caching built-in which was very useful on GitHub Actions which are far-away from `quay.io` and `registry.redhat.io` but it is slightly better in GitLab CICD - builds are a tad faster there. The question is if we want to cache or not to avoid getting throttled on those endpoints and how to do it. @croissanne mentioned using `ci-image-refresh-bot` I am not sure about that, but we might want to just drop this completely for now as well.

Note indentation of shell scripts is all over the place, this was already in the frontend repo and I only noticed later, instead of fixing it in this PR I will do a follow-up: https://github.com/osbuild/bootc-foundry/issues/8 (feel free to discuss in the issue tabs vs spaces :-D )

I wanted to keep this nice in few separate commits but as you can tell from amount of force-pushes, I was batting with gitlab permissions, setting up variables and getting it done. So all the mentioned changes are in one commit. Also, the spot instance termination is hard to test because I actually need a termination to happen in order to see that working, so that is why I wanted to have it earlier. Haven't encountered it yet tho.