### PR TITLE
fedora-qcow2: derived containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/*.local.sh
+/*.local.yaml

--- a/.tekton/rhel-10-1-qcow2-pull-request.yaml
+++ b/.tekton/rhel-10-1-qcow2-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: dockerfile
-    value: containerfiles/rhel-10.1-qcow2
+    value: rhel-10.1-qcow2
   - name: path-context
     value: .
   pipelineSpec:

--- a/.tekton/rhel-10-1-qcow2-push.yaml
+++ b/.tekton/rhel-10-1-qcow2-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:{{revision}}
   - name: dockerfile
-    value: containerfiles/rhel-10.1-qcow2
+    value: rhel-10.1-qcow2
   - name: path-context
     value: .
   pipelineSpec:

--- a/containerfiles/f43-qcow2
+++ b/containerfiles/f43-qcow2
@@ -1,3 +1,0 @@
-FROM quay.io/fedora/fedora-bootc:43
-
-RUN echo TODO

--- a/containerfiles/rhel-10.1-qcow2
+++ b/containerfiles/rhel-10.1-qcow2
@@ -1,3 +1,0 @@
-FROM registry.redhat.io/rhel10/rhel-bootc:10.1
-
-RUN echo TODO

--- a/containerfiles/stream10-qcow2
+++ b/containerfiles/stream10-qcow2
@@ -1,3 +1,0 @@
-FROM quay.io/centos-bootc/centos-bootc:stream10
-
-RUN echo TODO

--- a/containerfiles/stream9-qcow2
+++ b/containerfiles/stream9-qcow2
@@ -1,3 +1,0 @@
-FROM quay.io/centos-bootc/centos-bootc:stream9
-
-RUN echo TODO

--- a/el10-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
+++ b/el10-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
@@ -1,0 +1,6 @@
+match-architectures = ["x86_64"]
+kargs = [
+    "console=ttyS0",
+    "console=tty0",
+    "earlyprintk=ttyS0"
+]

--- a/el10-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
+++ b/el10-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
@@ -1,0 +1,5 @@
+match-architectures = ["aarch64"]
+kargs = [
+    "console=ttyAMA0",
+    "console=tty0"
+]

--- a/el9-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
+++ b/el9-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
@@ -1,0 +1,6 @@
+match-architectures = ["x86_64"]
+kargs = [
+    "console=ttyS0",
+    "console=tty0",
+    "earlyprintk=ttyS0"
+]

--- a/el9-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
+++ b/el9-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
@@ -1,0 +1,5 @@
+match-architectures = ["aarch64"]
+kargs = [
+    "console=ttyAMA0",
+    "console=tty0"
+]

--- a/f43-qcow2
+++ b/f43-qcow2
@@ -2,19 +2,19 @@
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
 
-FROM registry.redhat.io/rhel10/rhel-bootc:10.1
+FROM quay.io/fedora/fedora-bootc:43
 
 ARG TARGETARCH
 
 #
 # Extra packages:
 #
-# @guest-agents: Guest agents for QEMU and libvirt.
+# @guest-agents: Guest agents for QEMU and libvirt
 #
 RUN dnf install -y \
     @guest-agents \
     && dnf clean all
 
-COPY el10-qcow2-${TARGETARCH}/usr/ /usr/
+COPY fedora-qcow2-${TARGETARCH}/usr/ /usr/
 
-COPY rhel-10.1-qcow2 /root/Containerfile
+COPY f43-qcow2 /root/Containerfile

--- a/fedora-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
+++ b/fedora-qcow2-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
@@ -1,0 +1,5 @@
+match-architectures = ["x86_64"]
+kargs = [
+    "console=ttyS0",
+    "console=tty0",
+]

--- a/fedora-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
+++ b/fedora-qcow2-arm64/usr/lib/bootc/kargs.d/50-kargs-aarch64.toml
@@ -1,0 +1,5 @@
+match-architectures = ["aarch64"]
+kargs = [
+    "console=ttyAMA0",
+    "console=tty0"
+]

--- a/stream10-qcow2
+++ b/stream10-qcow2
@@ -2,7 +2,7 @@
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
 
-FROM registry.redhat.io/rhel10/rhel-bootc:10.1
+FROM quay.io/centos-bootc/centos-bootc:stream10
 
 ARG TARGETARCH
 
@@ -17,4 +17,4 @@ RUN dnf install -y \
 
 COPY el10-qcow2-${TARGETARCH}/usr/ /usr/
 
-COPY rhel-10.1-qcow2 /root/Containerfile
+COPY stream10-qcow2 /root/Containerfile

--- a/stream9-qcow2
+++ b/stream9-qcow2
@@ -2,7 +2,7 @@
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
 
-FROM registry.redhat.io/rhel10/rhel-bootc:10.1
+FROM quay.io/centos-bootc/centos-bootc:stream9
 
 ARG TARGETARCH
 
@@ -15,6 +15,6 @@ RUN dnf install -y \
     @guest-agents \
     && dnf clean all
 
-COPY el10-qcow2-${TARGETARCH}/usr/ /usr/
+COPY el9-qcow2-${TARGETARCH}/usr/ /usr/
 
-COPY rhel-10.1-qcow2 /root/Containerfile
+COPY stream9-qcow2 /root/Containerfile


### PR DESCRIPTION
This adds Fedora qcow2 derived containerfile. I wanted to start small, this is the most simple one. This PR is meant for discussion, I am making several assumptions which might be completely wrong.

## Image definitions

I used the `qcow2` and/or `cloud-qcow2` [image definitions](https://github.com/osbuild/images/blob/main/data/distrodefs) when writing those Containerfiles as inspiration and my workflow was dropping anything that is not needed or not relevant for bootc.

Assumption: users of the qcow2 image use cockpit-machines, libvirt or qemu/kvm directly. Although it is technically possible to use cloud-init in these environments, users must do additional configuration to achieve that (network endpoint, mount an ISO with seed info). Since image builder can actually help to set up users, passwords and ssh-keys, I am leaving cloud-init out of this.

I reviewed packages from both definitions and came up with the list that includes guest agents group plus some tools that might be required for storage/filesystems.

## Dropped packages

### Fedora

- "@server-product-environment"
- "@domain-client"
- "glibc-all-langpacks"

### EL10

- "@core"
- "chrony"
- "cloud-init"
- "cloud-utils-growpart"
- "cockpit-system"
- "cockpit-ws"
- "dnf-utils"
- "dosfstools"
- "nfs-utils"
- "oddjob"
- "oddjob-mkhomedir"
- "psmisc"
- "python3-jsonschema"
- "qemu-guest-agent"
- "redhat-release"
- "redhat-release-eula"
- "rsync"
- "system-reinstall-bootc"
- "tar"
- "tuned"
- "tcpdump"

## EL9

- "@core"
- "authselect-compat"
- "chrony"
- "cloud-init"
- "cloud-utils-growpart"
- "cockpit-system"
- "cockpit-ws"
- "dnf-utils"
- "dosfstools"
- "nfs-utils"
- "oddjob"
- "oddjob-mkhomedir"
- "psmisc"
- "python3-jsonschema"
- "qemu-guest-agent"
- "redhat-release"
- "redhat-release-eula"
- "rsync"
- "tar"
- "tuned"
- "tcpdump"

## Kernel command line and bootloader

These image definitions do set up kernel command line with focus on console and serial console. This is very useful in cockpit where console is fully native. Therefore I am including those arguments, but leaving out the speed which is not needed in virtualized environments.

I noticed that in other cloud environments we do also set grub2 kernel command line too. Shall we do that here?

```
GRUB_TERMINAL="serial console"
GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
```

Also, in other images we disable recovery, I did not find this in our distro defs either, so left this out:

```
GRUB_DISABLE_RECOVERY="true"
```

Personally, I would love a shorter timeout but I think we should stick with the default value.

```
GRUB_TIMEOUT=4
```

### Interface naming in EL9

I am not including the kernel command line option `net.ifnames=0` for EL9 image.

### Git repo organization

Now, few practical things. I am trying to keep as much files as possible out of the containerfile. I noticed that the pattern used in the bootc world is to have a single directory and have the `COPY` verb to do all the work, it copies recursively by default.

But we will need separate directories per version (when it drifts) and architecture so I created:

```
fedora-qcow2-amd64
└── usr
    └── lib
        └── bootc
            └── kargs.d
                └── 50-kargs-x86_64.toml
fedora-qcow2-arm64
└── usr
    └── lib
        └── bootc
            └── kargs.d
                └── 50-kargs-aarch64.toml
```

The verb actually automatically enforces root:root owner, unless specified otherwise via `--owner`, it also respects permissions but applies umask. Generally speaking, it should work and executable files will be kept.

## Testing the images

The image boots fine, serial console works nicely in libvirt, I cannot see or control grub via serial console because that is currently not configured.

### Initial setup - DROPPED

But, the initial-setup never disappears until it is confirmed in TUI/GUI. I think it does not make sense to have it in  derived containers, users can add it if they want. Therefore I am removing initial-setup.

```
1) [ ] Language settings                 2) [x] Time settings
       (Language is not set.)                   (America/New_York timezone)
3) [x] Network configuration             4) [!] Root password
       (Connected: enp1s0)                      (Root account is disabled)
5) [!] User creation
       (No user will be created)
```

### RHSM + Lightspeed

Works fine:

```
+-------------------------------------------+
   System Status Details
+-------------------------------------------+
Overall Status: Not registered

bash-5.2# rhc connect --activation-key xxxx --organization xxxx
Connecting localhost.localdomain to Red Hat.
This might take a few seconds.

Features preferences: [✓]content, [✓]analytics, [✓]remote-management

 [✓] Connected to Red Hat Subscription Management
  [✓] Content ... Red Hat repository file generated
  [✓] Analytics ... Connected to Red Hat Lightspeed (formerly Insights)
  [✓] Remote Management ... Activated the yggdrasil service

Successfully connected to Red Hat!

Manage your connected systems: https://red.ht/connector
```

### tuned - DROPPED

Is disabled by default, recognizes guest automatically:

```
bash-5.2# tuned-adm active
Current active profile: virtual-guest
```