### PR TITLE
templates/openshift: run container with pythonunbuffered

### DIFF
--- a/templates/openshift/containers.yml
+++ b/templates/openshift/containers.yml
@@ -19,8 +19,8 @@ objects:
         service: image-builder
       name: bootc-foundry-containers
     spec:
-      # run at midnight
-      schedule: 0 0 * * *
+      # every 20 minutes
+      schedule: "*/20 * * * *"
       concurrencyPolicy: Forbid
       # don't run if the job doesn't get scheduled within 30 minutes
       startingDeadlineSeconds: 1800

--- a/templates/openshift/containers.yml
+++ b/templates/openshift/containers.yml
@@ -36,6 +36,9 @@ objects:
                   args:
                     - "--repo"
                     - "${REPO}"
+                  env:
+                    - name: PYTHONUNBUFFERED
+                      value: "1"
                   resources:
                     requests:
                       cpu: "${CPU_REQUEST}"


### PR DESCRIPTION
Because it's throwing an exception, it seems not all output is flushed
    before exiting.
