### PR TITLE
schutzbot/gitlab-utils: fix trace_quiet/restore

### DIFF
--- a/schutzbot/gitlab-utils.sh
+++ b/schutzbot/gitlab-utils.sh
@@ -6,12 +6,15 @@ set -euo pipefail
 
 # Hide "set +x"/"set -x" from trace when possible (BASH_XTRACEFD).
 _trace_quiet() {
-    exec 3>/dev/null 2>/dev/null || true
-    BASH_XTRACEFD=3 set +x 2>/dev/null || set +x
+    if [[ $- == *x* ]]; then
+        set +x
+        echo -n 1
+    fi
+    echo -n 0
 }
 
 _trace_restore() {
-    BASH_XTRACEFD=3 set -x 2>/dev/null || set -x
+    set -x
 }
 
 # Prints a section start message to the console.
@@ -24,7 +27,8 @@ _trace_restore() {
 # Example:
 #   section_start build_image "Building image"
 function section_start() {
-    _trace_quiet
+    local restore_trace
+    restore_trace=$(_trace_quiet)
     local section_id="${1}_$$"
     local section_title=$2
     local collapsed=${3:-true}
@@ -32,7 +36,9 @@ function section_start() {
     [ "$collapsed" == "true" ] && params="[collapsed=true]"
 
     printf "\e[0Ksection_start:%s:%s%s\r\e[0K\e[1;36m%s\e[0m\n" "$(date +%s)" "$section_id" "$params" "$section_title"
-    _trace_restore
+    if [ "$restore_trace" == 1 ]; then
+       _trace_restore
+    fi
 }
 
 # Prints a section end message to the console.
@@ -43,8 +49,11 @@ function section_start() {
 # Example:
 #   section_end build_image
 function section_end() {
-    _trace_quiet
+    local restore_trace
+    restore_trace=$(_trace_quiet)
     local section_id="${1}_$$"
     printf "\e[0Ksection_end:%s:%s\r\e[0K\n" "$(date +%s)" "$section_id"
-    _trace_restore
+    if [ "$restore_trace" == 1 ]; then
+       _trace_restore
+    fi
 }


### PR DESCRIPTION
It was writing to FD3 which is not used anywhere, and it actually breaks using `set -x` in other parts because BASH_XTRACEFD is not a function-local variable.