### PR TITLE
cicd: skip checks in order to pass ecosystem-cert-preflight-checks

### DIFF
--- a/.tekton/rhel-10-1-qcow2-pull-request.yaml
+++ b/.tekton/rhel-10-1-qcow2-pull-request.yaml
@@ -58,7 +58,7 @@ spec:
         path-context
       name: dockerfile
       type: string
-    - default: "false"
+    - default: "true"
       description: Skip checks against built image
       name: skip-checks
       type: string

--- a/.tekton/rhel-10-1-qcow2-push.yaml
+++ b/.tekton/rhel-10-1-qcow2-push.yaml
@@ -55,7 +55,7 @@ spec:
         path-context
       name: dockerfile
       type: string
-    - default: "false"
+    - default: "true"
       description: Skip checks against built image
       name: skip-checks
       type: string


### PR DESCRIPTION
We need to run EnterpriseContract in order to get the final image pushed into the destination. But the train will not depart if there are checks failing. Currently the failing task `ecosystem-cert-preflight-checks` is blocking this.

Unfortunately, this cannot be self-serviced in Konflux, however, we can update it in our own pipelines. This is what this PR does. We can re-enable this if we find another way, or alternatively these jobs can be deleted completely from all tekton files in this repo.

It will also disable other checks, but these all have warnings anyway:

* ClamAV
* Coverity
* SNYK
* ShellCheck

If we start publishing these containers, then we need to align the integration test pipeline with bootc containers.

For the record, the failure is caused by series of checks which are designed for ubi containers but not bootc containers:

```
place-scripts :-
2026/04/01 15:36:53 Decoded script /tekton/scripts/script-0-h7k6s
2026/04/01 15:36:53 Decoded script /tekton/scripts/script-1-mn9rb
2026/04/01 15:36:54 Decoded script /tekton/scripts/script-2-xft5p
2026/04/01 15:36:54 Decoded script /tekton/scripts/script-3-s76mq
2026/04/01 15:36:54 Decoded script /tekton/scripts/script-4-ftzcj
2026/04/01 15:36:54 Decoded script /tekton/scripts/script-5-c5r4h
prepare :-
2026/04/01 15:36:53 Entrypoint initialization
step-generate-container-auth :-
Selecting auth for quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49
Using token for quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2
Auth json written to "/auth/auth.json".
step-introspect :-
Artifact type will be determined by introspection.
Checking the media type of the OCI artifact...
[retry] executing: skopeo inspect --raw --retry-times 3 docker://quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49
The media type of the OCI artifact is application/vnd.docker.distribution.manifest.v2+json.
Looking for image labels that indicate this might be an operator bundle...
[retry] executing: skopeo inspect --retry-times 3 docker://quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49
Found 0 matching labels.
Expecting 3 or more to identify this image as an operator bundle.
Introspection concludes that this artifact is of type "application".
step-app-check :-
time="2026-04-01T15:36:58Z" level=info msg="certification library version" version="1.16.0 <commit: b4a231cf9d50c5471eed598b3b48906eb5b9f3f7>"
time="2026-04-01T15:36:58Z" level=info msg="running checks for quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49 for platform amd64"
time="2026-04-01T15:36:58Z" level=info msg="target image" image="quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49"
time="2026-04-01T15:37:50Z" level=error msg="could not get rpm list, continuing without it" error="could not find rpm db/packages: stat /tmp/preflight-1741662189/fs/usr/lib/sysimage/rpm/rpmdb.sqlite: no such file or directory\nstat /tmp/preflight-1741662189/fs/var/lib/rpm/rpmdb.sqlite: no such file or directory\nstat /tmp/preflight-1741662189/fs/var/lib/rpm/Packages: no such file or directory"
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=HasLicense result=FAILED
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=LayerCountAcceptable result=FAILED
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=HasNoProhibitedPackages err="unable to get a list of all packages in the image: could not get rpm list: could not find rpm db/packages: stat /tmp/preflight-1741662189/fs/usr/lib/sysimage/rpm/rpmdb.sqlite: no such file or directory\nstat /tmp/preflight-1741662189/fs/var/lib/rpm/rpmdb.sqlite: no such file or directory\nstat /tmp/preflight-1741662189/fs/var/lib/rpm/Packages: no such file or directory" result=ERROR
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=HasRequiredLabel result=FAILED
time="2026-04-01T15:37:50Z" level=info msg="detected empty USER. Presumed to be running as root" check=RunAsNonRoot
time="2026-04-01T15:37:50Z" level=info msg="USER value must be provided and be a non-root value for this check to pass" check=RunAsNonRoot
time="2026-04-01T15:37:50Z" level=info msg="check completed" check=RunAsNonRoot result=FAILED
time="2026-04-01T15:38:17Z" level=info msg="check completed" check=HasModifiedFiles err="could not generate modified files list: could not open os-release: open /tmp/preflight-1741662189/fs/etc/os-release: no such file or directory" result=ERROR
time="2026-04-01T15:38:17Z" level=info msg="check completed" check=BasedOnUbi result=FAILED
time="2026-04-01T15:38:17Z" level=info msg="This image's tag d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49 will be paired with digest sha256:a74158b3892fc63761ce46d3ea873ea83c0b15bb8ee02aa3ca71fa1643bc2a69 once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49",
    "passed": false,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.16.0",
        "commit": "b4a231cf9d50c5471eed598b3b48906eb5b9f3f7"
    },
    "results": {
        "passed": [
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            }
        ],
        "failed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
                "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance.",
                "help": "Check LayerCountAcceptable encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Optimize your Dockerfile to consolidate and minimize the number of layers. Each RUN command will produce a new layer. Try combining RUN commands using \u0026\u0026 where possible.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata",
                "help": "Check HasRequiredLabel encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Add the following labels to your Dockerfile or Containerfile: name, vendor, version, release, summary, description, maintainer.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 250,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)",
                "help": "Check BasedOnUbi encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Change the FROM directive in your Dockerfile or Containerfile, for the latest list of images and details refer to: https://catalog.redhat.com/software/base-images",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
        "errors": [
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 0,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages.",
                "help": "Check HasNoProhibitedPackages encountered an error. Please review the preflight.log file for more information."
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 27600,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified",
                "help": "Check HasModifiedFiles encountered an error. Please review the preflight.log file for more information."
            }
        ]
    }
}
time="2026-04-01T15:38:20Z" level=info msg="Preflight result: FAILED"
step-set-skip-for-bundles :-
2026/04/01 15:36:58 INFO Step was skipped due to when expressions were evaluated to false.
step-app-set-outcome :-
{"result":"ERROR","timestamp":"1775057900","note":"Task preflight is a ERROR: Refer to Tekton task logs for more information","successes":1,"failures":5,"warnings":0}[retry] executing: skopeo inspect --raw --retry-times 3 docker://quay.io/redhat-user-workloads/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:d7293ce8bd2c862d8c8160d3a2c1b7e8ffa67e49
step-final-outcome :-
+ [[ ! -f /mount/konflux.results.json ]]
+ tee /tekton/steps/step-final-outcome/results/test-output
{"result":"ERROR","timestamp":"1775057900","note":"Task preflight is a ERROR: Refer to Tekton task logs for more information","successes":1,"failures":5,"warnings":0}
```