### PR TITLE
RHEL 10.1 x86_64 Azure derived container

### DIFF
--- a/azure-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
+++ b/azure-amd64/usr/lib/bootc/kargs.d/50-kargs-x86_64.toml
@@ -1,0 +1,9 @@
+match-architectures = ["x86_64"]
+kargs = [
+    "ro",
+    "console=ttyS0",
+    "console=tty0",
+    "earlyprintk=ttyS0",
+    "nvme_core.io_timeout=240",
+    "rootdelay=300"
+]

--- a/azure/etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+++ b/azure/etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
@@ -1,0 +1,2 @@
+[keyfile]
+unmanaged-devices=driver:mlx4_core;driver:mlx5_core;

--- a/azure/etc/chrony.d/10-azure-phc.conf
+++ b/azure/etc/chrony.d/10-azure-phc.conf
@@ -1,0 +1,1 @@
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0.0

--- a/azure/etc/cloud/cloud.cfg.d/10-azure-kvp.cfg
+++ b/azure/etc/cloud/cloud.cfg.d/10-azure-kvp.cfg
@@ -1,0 +1,5 @@
+reporting:
+  logging:
+    type: log
+  telemetry:
+    type: hyperv

--- a/azure/etc/cloud/cloud.cfg.d/91-azure_datasource.cfg
+++ b/azure/etc/cloud/cloud.cfg.d/91-azure_datasource.cfg
@@ -1,0 +1,4 @@
+datasource:
+  Azure:
+    apply_network_config: false
+datasource_list: [ Azure ]

--- a/azure/etc/cloud/cloud.cfg.d/91-bootc.cfg
+++ b/azure/etc/cloud/cloud.cfg.d/91-bootc.cfg
@@ -1,0 +1,6 @@
+# Resize root filesystem will fail on ostree/composefs based images.
+resize_rootfs: false
+
+# Creation of users (e.g. "azureuser") will fail on ostree/composefs based images.
+errors_retried_modules:
+  - users-groups

--- a/azure/etc/modprobe.d/blocklist.conf
+++ b/azure/etc/modprobe.d/blocklist.conf
@@ -1,0 +1,8 @@
+blacklist nouveau
+blacklist lbm-nouveau
+blacklist floppy
+blacklist amdgpu
+blacklist skx_edac
+blacklist intel_cstate
+blacklist intel_uncore
+blacklist acpi_cpufreq

--- a/azure/etc/ssh/sshd_config.d/50-clientalive.conf
+++ b/azure/etc/ssh/sshd_config.d/50-clientalive.conf
@@ -1,0 +1,1 @@
+ClientAliveInterval 180

--- a/azure/etc/sysconfig/network
+++ b/azure/etc/sysconfig/network
@@ -1,0 +1,2 @@
+NETWORKING=yes
+NOZEROCONF=yes

--- a/azure/etc/systemd/system/nm-cloud-setup.service.d/10-rh-enable-for-azure.conf
+++ b/azure/etc/systemd/system/nm-cloud-setup.service.d/10-rh-enable-for-azure.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=NM_CLOUD_SETUP_AZURE=yes

--- a/azure/etc/systemd/system/temp-disk-dataloss-warning.service
+++ b/azure/etc/systemd/system/temp-disk-dataloss-warning.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Azure temporary resource disk dataloss warning file creation
+After=multi-user.target cloud-final.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/temp-disk-dataloss-warning
+StandardOutput=journal+console
+
+[Install]
+WantedBy=default.target

--- a/azure/etc/waagent.conf
+++ b/azure/etc/waagent.conf
@@ -1,0 +1,2 @@
+ResourceDisk.Format=n
+ResourceDisk.EnableSwap=n

--- a/azure/usr/local/sbin/temp-disk-dataloss-warning
+++ b/azure/usr/local/sbin/temp-disk-dataloss-warning
@@ -1,0 +1,32 @@
+#!/bin/sh
+# /usr/local/sbin/temp-disk-dataloss-warning
+# Write dataloss warning file on mounted Azure resource disk
+
+AZURE_RESOURCE_DISK_PART1="/dev/disk/cloud/azure_resource-part1"
+
+MOUNTPATH=$(grep "$AZURE_RESOURCE_DISK_PART1" /etc/fstab | tr '\t' ' ' | cut -d' ' -f2)
+if [ -z "$MOUNTPATH" ]; then
+    echo "There is no mountpoint of $AZURE_RESOURCE_DISK_PART1 in /etc/fstab"
+    exit 0
+fi
+
+if [ "$MOUNTPATH" = "none" ]; then
+    echo "Mountpoint of $AZURE_RESOURCE_DISK_PART1 is not a path"
+    exit 1
+fi
+
+if ! mountpoint -q "$MOUNTPATH"; then
+    echo "$AZURE_RESOURCE_DISK_PART1 is not mounted at $MOUNTPATH"
+    exit 1
+fi
+
+echo "Creating a dataloss warning file at ${MOUNTPATH}/DATALOSS_WARNING_README.txt"
+
+cat <<'EOF' > "${MOUNTPATH}/DATALOSS_WARNING_README.txt"
+WARNING: THIS IS A TEMPORARY DISK.
+
+Any data stored on this drive is SUBJECT TO LOSS and THERE IS NO WAY TO RECOVER IT.
+
+Please do not use this disk for storing any personal or application data.
+
+EOF

--- a/rhel-10.1-azure
+++ b/rhel-10.1-azure
@@ -1,0 +1,40 @@
+# vim: set ft=dockerfile:
+# -*- mode: dockerfile-mode -*-
+# code: language=dockerfile insertSpaces=true tabSize=4
+
+FROM registry.redhat.io/rhel10/rhel-bootc:10.1
+
+ARG TARGETARCH
+
+#
+# Extra packages:
+#
+# cloud-init: cloud-init is a tool to configure cloud instances.
+# hyperv-daemons: required by cloud init (warns with 'failed posting events to kvp')
+# WALinuxAgent: WALinuxAgent is a tool to configure Windows Azure Linux Agent.
+#
+RUN dnf -y install \
+        cloud-init \
+		hyperv-daemons \
+        WALinuxAgent \
+    && dnf clean all
+
+# Copy common configuration
+COPY azure/etc/ /etc/
+COPY azure/usr/ /usr/
+
+# Copy architecture-specific configuration
+COPY azure-${TARGETARCH}/usr/ /usr/
+
+# Enable services after custom services are copied. Required hyperv-daemons services
+# consist of three separate services.
+RUN systemctl enable \
+    hypervkvpd.service \
+    hypervvssd.service \
+    hypervfcopyd.service \
+    waagent \
+    nm-cloud-setup.service \
+    nm-cloud-setup.timer \
+    temp-disk-dataloss-warning.service
+
+COPY rhel-10.1-azure /root/Containerfile


### PR DESCRIPTION
### azure: initial Containerfile

This image was created by converting our RHEL 10.1 "vhd" distrodef to a Containerfile, followed by a line-by-line review. The following is a list of refinements made during the conversion:

**Initial Conversion & Package Management**
* **Add converted Azure RHEL 10.1 Containerfile:** Bootstrapped via an AI-assisted conversion of the distrodef.
* **Drop excludes from `dnf install`:** The derived base image already contains many excluded packages (e.g., `linux-firmware`, `amd-gpu-firmware`, `nvidia-gpu-firmware`). Since these OCI layers cannot be dropped, excluding them offers no size optimization and would be inconsistent with the base image.
* **Drop already installed packages:** Removed explicit installs for packages that are already present by default (e.g., `bzip2`, `chrony`, `efibootmgr`, `hyperv-daemons`, `lvm2`, `NetworkManager`, `nvme-cli`, `selinux-policy`, `bootc`, `WALinuxAgent`, etc.).
* **Drop the package group:** Maintained the goal of keeping derived images as minimal as possible, matching our approach for `qcow2`.
* **Drop `langpacks-en` & keyboard config:** English is already the default in both the blueprint and the base image.
* **Drop remaining packages:** Removed all remaining packages except `cloud-init` and `WALinuxAgent`. (These can be re-added later if necessary).
* **Document packages section:** Added comments to maintain parity with `qcow2` images.

**System Configuration & Hardening**
* **Move `temp-disk-dataloss-warning` to separate file:** Moved into the `azure/` subdirectory for reuse across multiple versions and architectures, mirroring `qcow2`.
* **Disable Avahi daemon and link-local networking:** Configured directly instead of relying on legacy network configuration files. Recommended for cloud environments.
* **Add SSH client alive interval configuration:** Recommended for Azure; matches our RPM-based images.
* **Add kernel blocklist configuration:** Added modules recommended by RHEL docs, as well as recent distrodef additions that silence irrelevant VM boot warnings. 
* **Drop pwquality configuration:** This is handled in the base image (we also skip this for `qcow2`).
* **Add kargs for x86_64:** Extracted kernel arguments from the distrodef into a separate file. Validated against Microsoft/Red Hat docs (notably dropping `net.ifnames=0` and `loglevel=3 crashkernel=auto` for RHEL 10+).
* **Drop GRUB configuration:** GRUB serves as a static configuration for `bootc`, rather than traditional boot. Configuring a serial console currently requires ugly hacks (tracked in [[osbuild/bootc-foundry#35](https://github.com/osbuild/bootc-foundry/issues/35)](https://github.com/osbuild/bootc-foundry/issues/35)).

**Azure-Specific Integrations**
*(Note: The following configurations remain unchanged and are identical to our RPM-based images)*
* **Add Azure `cloud-init` datasource**
* **Add Azure `cloud-init` KVP reporting**
* **Add Azure `waagent` configuration**
* **Add Azure NetworkManager `cloud-setup` configuration**
* **Add Azure NetworkManager unmanaged devices configuration**
* **Add Azure chrony PHC configuration**

**Refactoring & Bug Fixes**
* **Remove default target config:** Redundant; already set in the base image.
* **Cleanup of enabled services:** Dropped unused services and those already active in the base image.
* **Move kargs configuration to architecture-specific directory:** Adopted a cleaner pattern: one common directory, plus specific subdirectories per arch/version for divergent files.
* **Move Containerfile copy to the end of the file:** Adjusted build sequence.
* **Enable services after custom services are copied:** Fixed a build failure where a custom service was being enabled before it was actually copied into the image.
* **Cleanup of the Containerfile:** General formatting and linting.
* **Move `no-link-local.conf` to `NetworkManager/conf.d`:** Corrected a typo where it was incorrectly placed in `etc/etc`.
* **Skip growpart and silence user errors for `cloud-init`:** Disabled `growpart` (unsupported for ostree/composefs based images), which resolves the `cloud-init: log_util.py[WARNING]: Failed to create user` warning.
* **Enable Hyper-V daemons:** Explicitly enabled all Hyper-V daemons for visibility, even though the RPM is already present in the base image.
* **Drop modernization of Avahi disablement:** Reverted previous disablement modernization.
* **Explain Hyper-V service enablement:** Added inline documentation to clarify the daemon enablement.
* **Put datasource on a single line:** Required by `cloud-init` due to how it parses the datasource early during the Linux boot process.