### PR TITLE
hummingbird-qcow2: add hummingbird-ci/bootc-os based container (HMS-10414)

### DIFF
--- a/hummingbird-qcow2
+++ b/hummingbird-qcow2
@@ -1,0 +1,21 @@
+FROM quay.io/hummingbird-ci/bootc-os:latest
+
+ARG TARGETARCH
+
+# The hummingbird repositories do not contain all dependencies for
+# cloud-init at this point in time.
+RUN dnf install -y fedora-repos
+
+RUN dnf install -y \
+    cloud-init \
+    && dnf clean all
+
+COPY qcow2-${TARGETARCH}/usr/ /usr/
+COPY hummingbird-qcow2-${TARGETARCH}/usr/ /usr/
+
+COPY hummingbird-qcow2 /root/Containerfile
+
+RUN systemctl preset-all
+
+# regenerate host keys, they're not present in the base image for some reason
+RUN ssh-keygen -A

--- a/hummingbird-qcow2-amd64/usr/lib/bootc/install/00-hummingbird.toml
+++ b/hummingbird-qcow2-amd64/usr/lib/bootc/install/00-hummingbird.toml
@@ -1,0 +1,2 @@
+[install.filesystem.root]
+type = "ext4"

--- a/hummingbird-qcow2-amd64/usr/lib/systemd/system-preset/81-cloud-init.preset
+++ b/hummingbird-qcow2-amd64/usr/lib/systemd/system-preset/81-cloud-init.preset
@@ -1,0 +1,5 @@
+enable cloud-init-local.service
+enable cloud-init-main.service
+enable cloud-init-network.service
+enable cloud-config.service
+enable cloud-final.service

--- a/hummingbird-qcow2-arm64/usr/lib/bootc/install/00-hummingbird.toml
+++ b/hummingbird-qcow2-arm64/usr/lib/bootc/install/00-hummingbird.toml
@@ -1,0 +1,2 @@
+[install.filesystem.root]
+type = "ext4"

--- a/hummingbird-qcow2-arm64/usr/lib/systemd/system-preset/81-cloud-init.preset
+++ b/hummingbird-qcow2-arm64/usr/lib/systemd/system-preset/81-cloud-init.preset
@@ -1,0 +1,5 @@
+enable cloud-init-local.service
+enable cloud-init-main.service
+enable cloud-init-network.service
+enable cloud-config.service
+enable cloud-final.service


### PR DESCRIPTION
As hummingbird is based on fedora, use the same kargs.