### PR TITLE
yamllint: ignore auto-generated .tekton/ files

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore: |
+  .tekton/
+
 rules:
   document-start: disable
   line-length:


### PR DESCRIPTION
The .tekton/ files are auto-generated by Konflux and use 2-space indentation throughout, which causes yamllint to report hundreds of indentation errors.

This change adds the .tekton/ directory to the yamllint ignore list so that linting focuses on manually-maintained YAML files.