### PR TITLE
Fix RHEL 10.1 installer ISO build failures (HMS-10568)

### DIFF
--- a/rhel-10.1-installer
+++ b/rhel-10.1-installer
@@ -50,7 +50,7 @@ grub2:
 EOT
 
 COPY <<EOT /usr/share/anaconda/interactive-defaults.ks
-bootc --source-imgref registry:quay.io/centos-bootc/centos-bootc:stream10 --target-imgref quay.io/centos-bootc/centos-bootc:stream10
+bootc --source-imgref local-storage://quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest
 EOT
 
 RUN echo "install:x:0:0:root:/root:/usr/libexec/anaconda/run-anaconda" >> /etc/passwd && \

--- a/rhel-10.1-installer
+++ b/rhel-10.1-installer
@@ -41,11 +41,11 @@ RUN dnf install -y \
 RUN mkdir -p /usr/lib/image-builder/bootc
 
 COPY <<EOT /usr/lib/image-builder/bootc/iso.yaml
-label: "CentOS-Stream-10-bootc-Installer"
+label: "RHEL-10.1-bootc-Installer"
 grub2:
   entries:
-    - name: "Install CentOS Stream 10 (bootc)"
-      linux: "/images/pxeboot/vmlinuz inst.stage2=hd:LABEL=CentOS-Stream-10-bootc-Installer console=tty0 inst.graphical selinux=0 rhgb quiet"
+    - name: "Install RHEL 10.1 (bootc)"
+      linux: "/images/pxeboot/vmlinuz inst.stage2=hd:LABEL=RHEL-10.1-bootc-Installer console=tty0 inst.graphical selinux=0 rhgb quiet"
       initrd: "/images/pxeboot/initrd.img"
 EOT
 

--- a/rhel-10.1-installer
+++ b/rhel-10.1-installer
@@ -6,6 +6,21 @@ FROM registry.redhat.io/rhel10/rhel-bootc:10.1
 
 ARG TARGETARCH
 
+# NOTE: bootc containers are shipped with empty /boot. While these images are created,
+# /boot is moved to /usr/lib/bootupd/updates by bootupd. When bootc install is
+# run to create a disk image, it calls bootupd that unpacks /usr/lib/bootupd/updates
+# back into /boot/efi.
+#
+# For the installer ISO image, we need the /boot to be populated, to fulfill the
+# container-native ISO contract (https://github.com/ondrejbudai/bootc-isos#container-native-iso-contract-v010).
+#
+# Reinstall shim-x64 to ensure that required files are not missing from /boot/efi/EFI
+#
+# This will have to change later due to https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+RUN dnf reinstall -y \
+    shim-x64 \
+    && dnf clean all
+
 # Packages needed for Anaconda; and build dependencies
 RUN dnf install -y \
     anaconda \
@@ -22,11 +37,6 @@ RUN dnf install -y \
     xorriso \
     squashfs-tools \
     && dnf clean all
-
-# XXX: https://github.com/osbuild/bootc-foundry/issues/50
-#RUN mkdir -p /boot/efi \
-#    && cp -rva /usr/lib/efi/*/*/EFI /boot/efi
-
 
 RUN mkdir -p /usr/lib/image-builder/bootc
 

--- a/rhel-10.1-installer
+++ b/rhel-10.1-installer
@@ -50,7 +50,9 @@ grub2:
 EOT
 
 COPY <<EOT /usr/share/anaconda/interactive-defaults.ks
-bootc --source-imgref local-storage://quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest
+# NOTE: the bootc command is available only in RHEL-10.2+
+#bootc --source-imgref local-storage://quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2:latest
+ostreecontainer --url=quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10.1-qcow2 --transport=containers-storage --no-signature-verification
 EOT
 
 RUN echo "install:x:0:0:root:/root:/usr/libexec/anaconda/run-anaconda" >> /etc/passwd && \


### PR DESCRIPTION
The [osbuild-composer `org.osbuild.grub2.iso` stage fails with `[Errno 2] No such file or directory: '/boot/efi/EFI/redhat/shimx64.efi'`](https://gitlab.com/redhat/services/products/image-builder/ci/osbuild-composer/-/jobs/14098012236#L8485) because bootc base images ship with an empty `/boot` — bootupd moves bootloader files to `/usr/lib/bootupd/updates` during image creation. Fix this by reinstalling `shim-x64` so the required EFI binaries are present under `/boot/efi/EFI`, fulfilling the container-native ISO contract. Also correct the ISO metadata and kickstart config for RHEL 10.1.

## Architectural Changes

Replace the previous commented-out workaround (manually copying from `/usr/lib/efi`) with a `dnf reinstall shim-x64` approach. This is cleaner because it lets the RPM scriptlets place files in their canonical locations. A comment notes this will need to change once the [Fedora BootLoaderUpdatesPhase1 change](https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1) lands upstream.

## Key Changes

- Reinstall `shim-x64` to populate `/boot/efi/EFI` with required EFI binaries, fixing the `org.osbuild.grub2.iso` stage failure
- Remove the old commented-out `cp -rva /usr/lib/efi` workaround (issue [#50](https://github.com/osbuild/bootc-foundry/issues/50))
- Update ISO label and GRUB boot entries from CentOS Stream 10 to RHEL 10.1
- Switch Anaconda kickstart `--source-imgref` to `local-storage://` and drop the now-redundant `--target-imgref`
- Use `ostreecontainer` command in the kickstart, instead of the `bootc` command, which is not available in RHEL 10.1.
