### PR TITLE
*qcow2: enable cloud-init (HMS-10531)

### DIFF
--- a/f43-qcow2
+++ b/f43-qcow2
@@ -10,9 +10,11 @@ ARG TARGETARCH
 # Extra packages:
 #
 # @guest-agents: Guest agents for QEMU and libvirt
+# cloud-init: cloud instance configuration tool
 #
 RUN dnf install -y \
     @guest-agents \
+    cloud-init \
     && dnf clean all
 
 # Copy common configuration

--- a/rhel-10.1-qcow2
+++ b/rhel-10.1-qcow2
@@ -10,9 +10,11 @@ ARG TARGETARCH
 # Extra packages:
 #
 # @guest-agents: Guest agents for QEMU and libvirt.
+# cloud-init: cloud instance configuration tool
 #
 RUN dnf install -y \
     @guest-agents \
+    cloud-init \
     && dnf clean all
 
 # Copy common configuration

--- a/stream10-qcow2
+++ b/stream10-qcow2
@@ -10,9 +10,11 @@ ARG TARGETARCH
 # Extra packages:
 #
 # @guest-agents: Guest agents for QEMU and libvirt.
+# cloud-init: cloud instance configuration tool
 #
 RUN dnf install -y \
     @guest-agents \
+    cloud-init \
     && dnf clean all
 
 # Copy common configuration

--- a/stream9-qcow2
+++ b/stream9-qcow2
@@ -10,10 +10,15 @@ ARG TARGETARCH
 # Extra packages:
 #
 # @guest-agents: Guest agents for QEMU and libvirt.
+# cloud-init: cloud instance configuration tool
 #
 RUN dnf install -y \
     @guest-agents \
+    cloud-init \
     && dnf clean all
+
+# Unlike EL10 or Fedora, EL9 doesn't have cloud-init in systemd preset, so we need to enable it manually.
+RUN systemctl enable cloud-init-local.service cloud-init.service cloud-config.service cloud-final.service
 
 # Copy common configuration
 #COPY qcow2/etc/ /etc/


### PR DESCRIPTION
Many qcow2 consumers (libvirt, openshift virt, openstack) use cloud-init to some first-boot initialization, so let's add it. Note that EL10 and Fedora already have it in systemd presets, so we don't need to enable it. For EL9, it's still needed.