### PR TITLE
hummingbird-qcow2: rename hummingbird community images org

### DIFF
--- a/hummingbird-qcow2
+++ b/hummingbird-qcow2
@@ -1,4 +1,4 @@
-FROM quay.io/hummingbird-ci/bootc-os:latest
+FROM quay.io/hummingbird-community/bootc-os:latest
 
 ARG TARGETARCH
 


### PR DESCRIPTION
The upstream org was renamed as "ci" doesn't normally mean "community images", and "ci" was previously the "throw everything in here" org so contained a lot of useless artifacts.

We've split out community images to their own org.  There may be another name change in a month or two when we find out where we want the **\<REDACTED\>** Hummingbird images to live.