### PR TITLE
ci: add GitHub Actions workflow to trigger GitLab CI (HMS-10336)

### DIFF
--- a/.github/workflows/gitlab-helper.yml
+++ b/.github/workflows/gitlab-helper.yml
@@ -1,0 +1,18 @@
+# This workflow runs on PRs and the merge queue and is responsible for starting
+# the "Start GitLab CI" workflow in a way that makes it possible to use
+# secrets. The workflow first runs source preparation to make sure that the
+# gitlab-ci.yml is up to date.
+---
+name: GitLab
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitlab-ci-helper:
+    name: "Gitlab CI trigger helper"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger
+        run: echo "GitLab trigger complete"

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,0 +1,74 @@
+# This workflow runs on success of the GitLab workflow.
+# If we run it on PR or merge_group, then we can't use secrets.
+---
+name: Start GitLab CI
+
+on:
+  workflow_run:
+    workflows: ["GitLab"]
+    types: [completed]
+
+jobs:
+  trigger-gitlab:
+    # this should never fail, but check it anyway in case we ever change it
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    env:
+      IMAGEBUILDER_BOT_GITLAB_SSH_KEY: ${{ secrets.IMAGEBUILDER_BOT_GITLAB_SSH_KEY }}
+    steps:
+      - name: Report status
+        uses: haya14busa/action-workflow_run-status@v1
+
+      - name: Apt update
+        run: sudo apt update
+
+      - name: Install Dependencies
+        run: |
+          sudo apt install -y jq
+
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Get open PRs
+        # Since this workflow doesn't run on a PR trigger, we need to find the
+        # PR number by querying the GH API and selecting on the commit ID
+        uses: octokit/request-action@v2.x
+        id: fetch_pulls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          route: GET /repos/${{ github.repository }}/pulls
+          per_page: 100
+
+      - name: Checkout branch
+        id: pr_data
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR_DATA=$(mktemp)
+          # use uuid as a file terminator to avoid conflicts with data content
+          cat > "$PR_DATA" <<'a21b3e7f-d5eb-44a3-8be0-c2412851d2e6'
+          ${{ steps.fetch_pulls.outputs.data }}
+          a21b3e7f-d5eb-44a3-8be0-c2412851d2e6
+
+          PR=$(jq -rc '.[] | select(.head.sha | contains("${{ github.event.workflow_run.head_sha }}")) | select(.state | contains("open"))' "$PR_DATA" | jq -r .number)
+          if [ ! -z "$PR" ]; then
+            # Create branch named PR-<number> to push to GitLab
+            echo "pr_branch=PR-$PR" >> "$GITHUB_OUTPUT"
+            git checkout -b PR-$PR
+          else
+            git checkout "${BRANCH}"
+          fi
+
+      - name: Push to GitLab
+        run: |
+          mkdir -p ~/.ssh
+          echo "${IMAGEBUILDER_BOT_GITLAB_SSH_KEY}" > ~/.ssh/id_rsa
+          chmod 400 ~/.ssh/id_rsa
+          touch ~/.ssh/known_hosts
+          ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
+          git remote add ci git@gitlab.com:redhat/services/products/image-builder/ci/bootc-foundry.git
+          git push -f ci

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+---
+stages:
+  - test
+
+no-op:
+  stage: test
+  script:
+    - echo "no-op"


### PR DESCRIPTION
Force-push the PR branch to GitLab as `PR-<number>`, which triggers the generated .gitlab-ci.yml pipeline. Status is reported back to GitHub. Follow the established osbuild-composer pattern.

This need to be on the default branch (`main`), before we can start testing anything in PRs...

This blocks testing of https://github.com/osbuild/bootc-foundry/pull/85