### PR TITLE
many: copy to /root and add rebuild instructions

### DIFF
--- a/rhel-10-azure
+++ b/rhel-10-azure
@@ -1,10 +1,21 @@
 # vim: set ft=dockerfile:
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
+#
+# To rebuild this host, run:
+#
+#   subscription-manager register && podman login registry.redhat.io
+#   podman build . -t system
+#   bootc switch --transport containers-storage localhost/system:latest
+#
+# For subsequent updates, run:
+#
+#   podman build . -t system
+#   bootc update
 
 FROM registry.redhat.io/rhel10/rhel-bootc:latest
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 #
 # Extra packages:
@@ -37,4 +48,8 @@ RUN systemctl enable \
     nm-cloud-setup.timer \
     temp-disk-dataloss-warning.service
 
-COPY rhel-10-azure /root/Containerfile
+# Copy sources to /root
+COPY rhel-10-azure /root/
+COPY azure/ /root/azure/
+COPY azure-${TARGETARCH}/ /root/azure-${TARGETARCH}/
+RUN ln -s /root/rhel-10-azure /root/Containerfile

--- a/rhel-10-ec2
+++ b/rhel-10-ec2
@@ -1,10 +1,21 @@
 # vim: set ft=dockerfile:
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
+#
+# To rebuild this host, run:
+#
+#   subscription-manager register && podman login registry.redhat.io
+#   podman build . -t system
+#   bootc switch --transport containers-storage localhost/system:latest
+#
+# For subsequent updates, run:
+#
+#   podman build . -t system
+#   bootc update
 
 FROM registry.redhat.io/rhel10/rhel-bootc:latest
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 #
 # Extra packages:
@@ -26,4 +37,8 @@ RUN systemctl enable \
 COPY ec2/etc/ /etc/
 COPY ec2-${TARGETARCH}/usr/ /usr/
 
-COPY rhel-10-ec2 /root/Containerfile
+# Copy sources to /root
+COPY rhel-10-ec2 /root/
+COPY ec2/ /root/ec2/
+COPY ec2-${TARGETARCH}/ /root/ec2-${TARGETARCH}/
+RUN ln -s /root/rhel-10-ec2 /root/Containerfile

--- a/rhel-10-gcp
+++ b/rhel-10-gcp
@@ -1,10 +1,21 @@
 # vim: set ft=dockerfile:
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
+#
+# To rebuild this host, run:
+#
+#   subscription-manager register && podman login registry.redhat.io
+#   podman build . -t system
+#   bootc switch --transport containers-storage localhost/system:latest
+#
+# For subsequent updates, run:
+#
+#   podman build . -t system
+#   bootc update
 
 FROM registry.redhat.io/rhel10/rhel-bootc:latest
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 # Copy arch-specific files before dnf install
 COPY gcp-${TARGETARCH}/etc/ /etc/
@@ -18,4 +29,8 @@ RUN dnf -y install \
 # Copy common configuration
 COPY gcp/etc/ /etc/
 
-COPY rhel-10-gcp /root/Containerfile
+# Copy sources to /root
+COPY rhel-10-gcp /root/
+COPY gcp/ /root/gcp/
+COPY gcp-${TARGETARCH}/ /root/gcp-${TARGETARCH}/
+RUN ln -s /root/rhel-10-gcp /root/Containerfile

--- a/rhel-10-installer
+++ b/rhel-10-installer
@@ -1,10 +1,21 @@
 # vim: set ft=dockerfile:
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
+#
+# To rebuild this host, run:
+#
+#   subscription-manager register && podman login registry.redhat.io
+#   podman build . -t system
+#   bootc switch --transport containers-storage localhost/system:latest
+#
+# For subsequent updates, run:
+#
+#   podman build . -t system
+#   bootc update
 
 FROM registry.redhat.io/rhel10/rhel-bootc:latest
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 # NOTE: bootc containers are shipped with empty /boot. While these images are created,
 # /boot is moved to /usr/lib/bootupd/updates by bootupd. When bootc install is
@@ -91,3 +102,7 @@ COPY <<EOT /etc/systemd/user/pipewire.socket.d/allowroot.conf
 [Unit]
 ConditionUser=
 EOT
+
+# Copy sources to /root
+COPY rhel-10-installer /root/
+RUN ln -s /root/rhel-10-installer /root/Containerfile

--- a/rhel-10-qcow2
+++ b/rhel-10-qcow2
@@ -1,10 +1,21 @@
 # vim: set ft=dockerfile:
 # -*- mode: dockerfile-mode -*-
 # code: language=dockerfile insertSpaces=true tabSize=4
+#
+# To rebuild this host, run:
+#
+#   subscription-manager register && podman login registry.redhat.io
+#   podman build . -t system
+#   bootc switch --transport containers-storage localhost/system:latest
+#
+# For subsequent updates, run:
+#
+#   podman build . -t system
+#   bootc update
 
 FROM registry.redhat.io/rhel10/rhel-bootc:latest
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 #
 # Extra packages:
@@ -17,11 +28,9 @@ RUN dnf install -y \
     cloud-init \
     && dnf clean all
 
-# Copy common configuration
-#COPY qcow2/etc/ /etc/
-#COPY qcow2/usr/ /usr/
-
-# Copy architecture-specific configuration
 COPY qcow2-${TARGETARCH}/usr/ /usr/
 
-COPY rhel-10-qcow2 /root/Containerfile
+# Copy sources to /root
+COPY rhel-10-qcow2 /root/
+COPY qcow2-${TARGETARCH}/ /root/qcow2-${TARGETARCH}/
+RUN ln -s /root/rhel-10-qcow2 /root/Containerfile


### PR DESCRIPTION
This fixes COPY verbs for `/root` and adds instructions to each containefile.

This also adds a default ARCH value of `amd64` so x86_64 users can rebuild without any podman ENV arguments from the get-go.

I tested this on qcow2 locally, then used Cursor to apply the same updates to other files.