### PR TITLE
rhel-10-installer: add fuse-overlayfs

### DIFF
--- a/rhel-10-installer
+++ b/rhel-10-installer
@@ -36,6 +36,7 @@ RUN dnf install -y \
     google-noto-sans-cjk-fonts \
     xorriso \
     squashfs-tools \
+    fuse-overlayfs \
     && dnf clean all
 
 RUN mkdir -p /usr/lib/image-builder/bootc


### PR DESCRIPTION
Anaconda needs this in order to deploy the payload container. It seems the containers-common package is missing a dependency.