### PR TITLE
CODEOWNERS: use 'osbuild-reviewers' group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*               @osbuild/all-reviewers
+*               @osbuild/osbuild-reviewers


### PR DESCRIPTION
Previously, the '@osbuild/all-reviewers' group was set as the CODEOWNERS for this repository. However, that group never had write access to the repository, so nobody was ever auto-assigned to any PR.

The group is quite wide and used for low volume repos. The bootc-foundry repository fits more into the group of projects like images, osbuild, etc. Change the group to '@osbuild/osbuild-reviewers' group.