### PR TITLE
Add weekly forced rebuild workflow (HMS-10237)

### DIFF
--- a/.github/workflows/force-rebuild.yml
+++ b/.github/workflows/force-rebuild.yml
@@ -1,0 +1,53 @@
+name: Force rebuild
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Wednesday at 05:00 UTC (all US time zones asleep)
+    - cron: "0 5 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  force-rebuild:
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
+
+      - name: Configure git user
+        run: |
+          git config user.name "schutzbot"
+          git config user.email "schutzbot@gmail.com"
+
+      - name: Bump rebuild timestamp
+        id: bump
+        run: |
+          timestamp=$(python3 schutzbot/bump_rebuild_timestamp.py)
+          echo "timestamp=${timestamp}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        run: |
+          if git diff --quiet; then echo "No changes"; exit 0; fi
+          timestamp="${{ steps.bump.outputs.timestamp }}"
+          branch="force-rebuild-${timestamp}"
+          git checkout -b "${branch}"
+          git add Schutzfile
+          git commit -m "schutzfile: force rebuild ${timestamp}"
+          git push -f origin "${branch}"
+          existing_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number')
+          if [ -n "$existing_pr" ]; then
+            echo "PR #${existing_pr} already exists for branch ${branch}; skipping."
+            exit 0
+          fi
+          gh pr create \
+            --title "Force rebuild ${timestamp}" \
+            --body "Periodic forced rebuild to trigger full CI testing and Konflux pipeline rebuilds." \
+            --base "main" \
+            --head "${branch}"

--- a/Schutzfile
+++ b/Schutzfile
@@ -1,5 +1,6 @@
 {
   "common": {
+    "last-forced-rebuild": "000000000000",
     "dependencies": {
       "images": {
         "ref": "dac29a33b6d4b830baa6134bd9e4e7256e786d27"

--- a/schutzbot/bump_rebuild_timestamp.py
+++ b/schutzbot/bump_rebuild_timestamp.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json
+from datetime import datetime, timezone
+
+# Relative to repo root; must be run from the repo top-level directory.
+SCHUTZFILE = "Schutzfile"
+
+
+def bump_rebuild_timestamp():
+    with open(SCHUTZFILE, encoding="utf-8") as f:
+        data = json.load(f)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M")
+    data["common"]["last-forced-rebuild"] = timestamp
+
+    with open(SCHUTZFILE, encoding="utf-8", mode="w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+    return timestamp
+
+
+def main():
+    timestamp = bump_rebuild_timestamp()
+    print(timestamp)
+
+
+if __name__ == "__main__":
+    main()

--- a/stream10-installer
+++ b/stream10-installer
@@ -6,6 +6,21 @@ FROM quay.io/centos-bootc/centos-bootc:stream10
 
 ARG TARGETARCH
 
+# NOTE: bootc containers are shipped with empty /boot. While these images are created,
+# /boot is moved to /usr/lib/bootupd/updates by bootupd. When bootc install is
+# run to create a disk image, it calls bootupd that unpacks /usr/lib/bootupd/updates
+# back into /boot/efi.
+#
+# For the installer ISO image, we need the /boot to be populated, to fulfill the
+# container-native ISO contract (https://github.com/ondrejbudai/bootc-isos#container-native-iso-contract-v010).
+#
+# Reinstall shim-x64 to ensure that required files are not missing from /boot/efi/EFI
+#
+# This will have to change later due to https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+RUN dnf reinstall -y \
+    shim-x64 \
+    && dnf clean all
+
 # Packages needed for Anaconda; and build dependencies
 RUN dnf install -y \
     anaconda \
@@ -24,8 +39,10 @@ RUN dnf install -y \
     fuse-overlayfs \
     && dnf clean all
 
-RUN mkdir -p /boot/efi \
-    && cp -rva /usr/lib/efi/*/*/EFI /boot/efi
+# NOTE: This stopped working on the latest c10s images, because nothing is installing to /usr/lib/efi/*/*/EFI
+# shim-x64 is still installing to /boot/efi as of shim-x64-16.1-1.el10.x86_64. See the section above for more details.
+# RUN mkdir -p /boot/efi \
+#     && cp -rva /usr/lib/efi/*/*/EFI /boot/efi
 
 
 RUN mkdir -p /usr/lib/image-builder/bootc


### PR DESCRIPTION
Introduce a scheduled GitHub Actions workflow that triggers a full CI test cycle and Konflux pipeline rebuild every Wednesday. The workflow bumps a timestamp in the Schutzfile and opens a PR against main, leveraging the existing GitLab CI trigger on Schutzfile changes to force all jobs to run.

I've also had to fix the `stream10-installer` Containerfile, because the `/usr/lib/efi/*/*/EFI` path is no longer populated in the image. I was not able to determine the root cause of this issue - IOW what changed. `shim` package still installs all packages under `/boot`.

## Architectural Changes

The bump logic is extracted into a standalone Python script (`schutzbot/bump_rebuild_timestamp.py`) rather than inline shell in the workflow, enabling easy local testing and reuse. A new `last-forced-rebuild` key is added to the Schutzfile's `common` section, initialized to `"000000000000"`.

## Key Changes

- Add `.github/workflows/force-rebuild.yml` — scheduled weekly (Wednesday 05:00 UTC) and manual dispatch, creates a PR with the bumped timestamp
- Add `schutzbot/bump_rebuild_timestamp.py` — writes current UTC timestamp (YYYYMMDDHHMM) into Schutzfile
- Seed `Schutzfile` with `last-forced-rebuild` field so the first bump produces a clean diff
- Workflow is idempotent: skips PR creation if one already exists for the same timestamp branch

## Testing

- The Python script can be tested locally by running `python3 schutzbot/bump_rebuild_timestamp.py` from the repo root
- Workflow can be triggered manually via `workflow_dispatch` to verify end-to-end behavior before the first scheduled run